### PR TITLE
Adapt js_interop types casts to support WASM builds

### DIFF
--- a/motion_web/lib/src/motion.dart
+++ b/motion_web/lib/src/motion.dart
@@ -185,20 +185,19 @@ class WebMotion extends MotionPlatform {
     Scripts.load();
 
     _isSafariMobile =
-        web.window.callMethod('isSafariMobile'.toJS) as bool? ?? false;
+        web.window.callMethod<JSBoolean>('isSafariMobile'.toJS).toDart;
 
     _isGyroscopeApiAvailable =
-        web.window.callMethod('isGyroscopeApiAvailable'.toJS) as bool? ?? false;
-    _isDeviceMotionApiAvailable =
-        web.window.callMethod('isDeviceMotionApiAvailable'.toJS) as bool? ??
-            false;
+        web.window.callMethod<JSBoolean>('isGyroscopeApiAvailable'.toJS).toDart;
+    _isDeviceMotionApiAvailable = web.window
+        .callMethod<JSBoolean>('isDeviceMotionApiAvailable'.toJS)
+        .toDart;
 
     if (_isDeviceMotionApiAvailable) {
       // If a permission is required to access the DeviceMotionEvents, we are sure there is a gyroscope on the device.
-      _isPermissionRequired =
-          web.window.callMethod('requiresDeviceMotionEventPermission'.toJS)
-                  as bool? ??
-              false;
+      _isPermissionRequired = web.window
+          .callMethod<JSBoolean>('requiresDeviceMotionEventPermission'.toJS)
+          .toDart;
 
       if (_isPermissionRequired) {
         _isPermissionGranted = await evaluatePermission as bool? ?? false;
@@ -215,8 +214,8 @@ class WebMotion extends MotionPlatform {
   @override
   Future<bool> requestPermission() async {
     _isPermissionGranted = web.window
-            .callMethod('requestDeviceMotionEventPermission'.toJS) as bool? ??
-        false;
+        .callMethod<JSBoolean>('requestDeviceMotionEventPermission'.toJS)
+        .toDart;
 
     return _isPermissionGranted;
   }

--- a/motion_web/lib/src/scripts.dart
+++ b/motion_web/lib/src/scripts.dart
@@ -1,12 +1,13 @@
+import 'dart:js_interop';
 import 'package:web/web.dart' as web;
 
 class Scripts {
   static void load() {
-    dynamic scriptText = detectionScript.minified;
-      
+    final scriptText = detectionScript.minified;
+
     web.document.body?.append(web.HTMLScriptElement()
       ..type = 'application/javascript'
-      ..innerHTML = scriptText);
+      ..innerHTML = scriptText.toJS);
   }
 }
 


### PR DESCRIPTION
Closes #24

As reported by @Maatteogekko, WASM web builds produce a runtime exception indicating a type cast error when initializing the package.

This used to work in previous versions but no longer works since the latest Flutter SDK changes related to WASM support.

Now that we cast `js_interop` types the right way, the example app successfully compiles and runs as expected when targeting WASM.